### PR TITLE
Add support for HokieTEAM

### DIFF
--- a/NewHokieTEAM.html
+++ b/NewHokieTEAM.html
@@ -1,0 +1,105 @@
+<div class="uk-flex uk-flex-wrap uk-flex-wrap-between uk-flex-middle" id="content">
+
+    <!-- CASH MONEY SECTION -->
+    <div class="uk-card uk-card-default uk-card-body uk-margin-auto uk-margin" style="width: 30em; margin-top: 1em;">
+        <h3 class="uk-card-title">Benefits and Pay</h3>
+
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=pmenu.P_BenMenu"
+            uk-tooltip="View your retirement plans, Health insurance information, miscellaneous deductions.">
+            <span id="icon" uk-icon="link" ></span> Benefits and Deductions
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_MostRecentPayStub"
+            uk-tooltip="Displays your most recent pay stub or the pay stub selection page if you have more than one paycheck in the most recent pay period.">
+            <span id="icon" uk-icon="link" ></span> Most Recent Pay Stub
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_PayMenu"
+            uk-tooltip="View your Payroll Direct Deposit breakdown; View your Earnings and Deductions History; View your Pay Stubs; Change your Pay Stub Selection.">
+            <span id="icon" uk-icon="link" ></span> Pay Information
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_Current_Status"
+            uk-tooltip="Update your Direct Deposit information. Payroll, Student Refunds and other University reimbursements can be automatically deposited into your bank account.">
+            <span id="icon" uk-icon="link" ></span> Direct Deposit
+        </a>
+    </div>
+
+    <!-- Employment Information -->
+
+    <div class="uk-card uk-card-default uk-card-body uk-margin-auto uk-margin" style="width: 30em">
+        <h3 class="uk-card-title">Employment Information</h3>
+
+        <a id="link" class="uk-link-heading" href="/ssb/prod/hzskmajr.P_ViewJobs"
+            uk-tooltip="View current and past jobs.">
+            <span id="icon" uk-icon="link" ></span>Current and Past Jobs
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/hzskvtrq.P_ViewLeaveBalancesVT" 
+            uk-tooltip="View your hire dates, training dates, and leave balances for salaried employees.">
+            <span id="icon" uk-icon="link" ></span>Employment Information
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/hzskcreq.P_DispClass"
+            uk-tooltip="Attention Veterans - please update your discharge date and Veteran Classifications.">
+            <span id="icon" uk-icon="link" ></span>Veterans Classification
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/hzskcreq.P_SelectEthnicityRace"
+            uk-tooltip="View and update your ethnicity and race information.">
+            <span id="icon" uk-icon="link" ></span>Update Ethnicity and Race
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_DispDisab"
+            uk-tooltip="View and update your disability information.">
+            <span id="icon" uk-icon="link" ></span>Update Voluntary Self-Identification of Disability Information
+        </a>
+    </div>
+
+    <!-- Employment Tools -->
+    <div class="uk-card uk-card-default uk-card-body uk-margin-auto uk-margin" style="width: 30em">
+        <h3 class="uk-card-title">Tools</h3>
+
+        <a id="link" class="uk-link-heading" href="/ssb/prod/bwskgstu.P_launch_flex"
+            uk-tooltip="Initiate and approve retroactive employee payroll funding changes.">
+            <span id="icon" uk-icon="link" ></span>Labor Redistribution
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_PerformanceMnu"
+            uk-tooltip="Performance Planning and Evaluation Tool.">
+            <span id="icon" uk-icon="link" ></span>Performance Planning and Evaluation Tool
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_tae_redirect"
+            uk-tooltip="Travel and Expense system used for travel authorizations and travel reimbursements.">
+            <span id="icon" uk-icon="link" ></span>TEM Application
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_cashiering_redirect"
+            uk-tooltip="Connects to the CashNet cashiering system.">
+            <span id="icon" uk-icon="link" ></span>University Cashiering System
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="https://webapps.es.vt.edu/leave/"
+            uk-tooltip="View and submit leave reports.">
+            <span id="icon" uk-icon="link" ></span>Leave Entry and Reporting
+        </a>
+    </div>
+
+    <!-- Paycheck Withholding -->
+    <div class="uk-card uk-card-default uk-card-body uk-margin-auto uk-margin" style="width: 30em">
+        <h3 class="uk-card-title">Paycheck Withholdings</h3>
+
+        <a id="link" class="uk-link-heading" href="/ssb/prod/hzskferp.P_gradcomp_redirect"
+            uk-tooltip="Eligible graduate students on assistantship manage or enroll in the Graduate Comprehensive Fee Payment Plan.">
+            <span id="icon" uk-icon="link" ></span>Graduate Comprehensive Fee Payment Plan
+        </a>
+        <br>
+        <a id="link" class="uk-link-heading" href="/ssb/prod/hzskgsta.P_GuestUpd"
+            uk-tooltip="View and update your W-4 and VA-4 information; View your W-2 Form and/or 1042S Form (if applicable).">
+            <span id="icon" uk-icon="link" ></span>Tax Forms
+        </a>
+    </div>
+
+
+</div>

--- a/NewTeamHeader.html
+++ b/NewTeamHeader.html
@@ -1,0 +1,50 @@
+<!-- HEADER -->
+<div class="uk-flex uk-flex-column" style="width: 100%">
+	<div class="uk-flex uk-flex-left uk-flex-middle" style="background-color: #630031; width: 100%">
+		<img class="uk-margin-left uk-margin uk-margin-top" style="height: 2em;"
+			src="//assets.cms.vt.edu/global_assets/images/logo.svg" alt="VT Logo">
+		<h4 style="color: #ffffff" class="uk-margin-left uk-margin-top uk-margin-bottom">
+			Student, Faculty, Employee, and Alumni Information Gateway
+		</h4>
+	</div>
+	<span style="height: 4px; background-color: #CF4420; display: block; width: 100%;"></span></img>
+
+	<div class="uk-margin-left uk-margin-right uk-flex uk-margin-top"
+		style="margin-bottom: -1em">
+
+		<!-- Search Bar and HokieSpa / HokiePLUS nav -->
+		<div class="uk-text-lead uk-margin-right">Search: </div>
+
+		<div class=" uk-flex-left uk-flex-middle">
+			<form class="uk-search uk-search-default" action="/ssb/prod/twbksrch.P_ShowResults" method="post">
+				<div class="uk-flex uk-flex-center">
+					<button type="submit" uk-search-icon></button>
+					<input class="uk-search-input" type="search" placeholder="" name="KEYWRD_IN" size="20"
+						maxlength="65" id="keyword_in_id">
+				</div>
+			</form>
+		</div>
+		<div>
+			<h3 class="uk-text-lead uk-margin-large-left">
+				<a class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_GenMnu">
+					Hokie PLUS
+				</a>
+			</h3>
+		</div>
+		<div>
+			<h3 class="uk-text-lead uk-margin-large-left">
+				<a class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_StuMainMnu">
+					Hokie Spa
+				</a>
+			</h3>
+        </div>
+        <div>
+			<h3 class="uk-text-lead uk-margin-large-left">
+				<a class="uk-link-heading" href="/ssb/prod/twbkwbis.P_GenMenu?name=pmenu.P_MainMnu">
+					Hokie TEAM
+				</a>
+			</h3>
+		</div>
+	</div>
+</div>
+<!-- /HEADER -->

--- a/injectHTML.js
+++ b/injectHTML.js
@@ -1,15 +1,30 @@
 
 // this function decides how to load a given page depending on the URL
 function load(destURL) {
-
+    var dispTeam = false;
+    var tabs = document.getElementsByClassName("taboff");
+    for (var i = 0; i < tabs.length; i++) {
+        if (tabs[i].innerHTML.toString().includes("Team")) {
+            dispTeam = true;
+        }
+    }
     if (destURL == "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_MainMnu") {
         //homepage
         document.body.innerHTML = null;
-        loadHTML("NewHeader.html", function () {
-            loadHTML('NewHome.html', function () {
-                loadHTML("NewFooter.html", function () { });
+        if (dispTeam) {
+            loadHTML("NewTeamHeader.html", function () {
+                loadHTML('NewHome.html', function () {
+                    loadHTML("NewFooter.html", function () { });
+                });
             });
-        });
+        }
+        else {
+            loadHTML("NewHeader.html", function () {
+                loadHTML('NewHome.html', function () {
+                    loadHTML("NewFooter.html", function () { });
+                });
+            });
+    }
 
     }
     else if (destURL == "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_WWWLogin") {
@@ -22,40 +37,77 @@ function load(destURL) {
         var results = getNewSearchResults();
         document.body.innerHTML = null;
 
-        loadHTML("NewHeader.html", function () {            
-            loadHTML('NewResults.html', function () {
+        if (dispTeam) {
+            loadHTML("NewTeamHeader.html", function () {
+                loadHTML('NewResults.html', function () {
                 loadNewSearchResults(results);
 
-                loadHTML("NewFooter.html", function () { });
+                    loadHTML("NewFooter.html", function () { });
+                });
             });
+        }
+        else {
+            loadHTML("NewHeader.html", function () {
+                loadHTML('NewResults.html', function () {
+                loadNewSearchResults(results);
 
-        });
+                    loadHTML("NewFooter.html", function () { });
+                });
+            });
+        }
     }
     else if (destURL == "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_StuMainMnu" ||
         destURL == "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_StuMainMnu#") {
-
+        //hokiespa
         document.body.innerHTML = null;
 
-        //hokiespa
-        loadHTML("NewHeader.html", () => {
-            loadHTML('NewNeck.html', () => {
-                loadHTML('NewHokieSpaHome.html', () => {
-                    loadHTML("NewFooter.html", () => { })
-                })
-            })
-        });
+        
+        if (dispTeam) {
+            loadHTML("NewTeamHeader.html", function () {
+                loadHTML('NewHokieSpaHome.html', function () {
+                    loadHTML("NewFooter.html", function () { });
+                });
+            });
+        }
+        else {
+            loadHTML("NewHeader.html", function () {
+                loadHTML('NewHokieSpaHome.html', function () {
+                    loadHTML("NewFooter.html", function () { });
+                });
+            });
+        }
     }
+    else if (destURL == "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=pmenu.P_MainMnu") {
+    //hokieteam
+
+    document.body.innerHTML = null;
+
+    loadHTML("NewTeamHeader.html", () => {
+        loadHTML('NewHokieTEAM.html', () => {
+            loadHTML("NewFooter.html", () => { })
+        })
+    });
+
+}
     else if (destURL == "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_GenMnu") {
         //hokieplus
 
         document.body.innerHTML = null;
 
-        loadHTML("NewHeader.html", () => {
-            loadHTML('NewHokiePLUS.html', () => {
-                loadHTML("NewFooter.html", () => { })
-            })
-        });
-
+        if (dispTeam) {
+            loadHTML("NewTeamHeader.html", function () {
+                loadHTML('NewHokiePLUS.html', function () {
+                    loadHTML("NewFooter.html", function () { });
+                });
+            });
+        }
+        else {
+            loadHTML("NewHeader.html", function () {
+                loadHTML('NewHokiePLUS.html', function () {
+                    loadHTML("NewFooter.html", function () { });
+                });
+            });
+        }
     }
 
     // deleting all of the css in the window so it doesnt screw with my stuff

--- a/manifest.json
+++ b/manifest.json
@@ -14,11 +14,13 @@
     "NewHome.html",
     "NewResults.html",
     "NewHokieSpaHome.html",
+    "NewHokieTEAM.html", 
     "NewHokiePLUS.html",
     "NewNeck.html",
     "NewHeader.html",
     "NewFooter.html",
-    "NewListElement.html"
+    "NewListElement.html",
+    "NewTeamHeader.html"
   ],
   "content_scripts": [
     {
@@ -27,7 +29,8 @@
         "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_MainMnu",
         "https://banweb.banner.vt.edu/ssb/prod/twbksrch.P_ShowResults",
         "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_StuMainMnu",
-        "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_GenMnu"
+        "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=bmenu.P_GenMnu",
+		    "https://banweb.banner.vt.edu/ssb/prod/twbkwbis.P_GenMenu?name=pmenu.P_MainMnu"
       ],
       "css": [
         "css/uikit-rtl.css",


### PR DESCRIPTION
This adds support for the HokieTEAM (Tech Employee Access Menu) homepage, it adds a new page to modernify that page and adds a new seperate header that includes a tab for HokieTeam. In theory it should automatically add that tab only if the user has access to HokieTeam but I haven't been able to test that as I don't have access to an account without access. All original pages were tested in Chrome and function as they did originally.